### PR TITLE
Gpu drifter re-drift

### DIFF
--- a/python/CompareSchemes2D.ipynb
+++ b/python/CompareSchemes2D.ipynb
@@ -487,7 +487,7 @@
     "    fig.suptitle(\"KP07 Time = \" + \"{:04.0f}\".format(t) + \" s\", fontsize=18)\n",
     "\n",
     "    if (i%10 == 0):\n",
-    "        print \"{:03.0f}\".format(100*i / T) + \" % => t=\" + str(t) + \"\\tMax h: \" + str(np.max(h1))\n",
+    "        print \"{:03.0f}\".format(100*i / T) + \" % => t=\" + str(t) + \"\\tMax h: \" + str(np.max(eta1))\n",
     "        #fig.savefig(imgdir + \"/{:010.0f}_kp07.png\".format(t))\n",
     "             \n",
     "anim = animation.FuncAnimation(fig, animate, range(T), interval=100)\n",

--- a/python/PassiveGPUDrifter.ipynb
+++ b/python/PassiveGPUDrifter.ipynb
@@ -432,8 +432,8 @@
     "T = 200\n",
     "sub_t = 1000*dt\n",
     "#loopsPerFrame = 10\n",
-    "#oceanParticleSets = [oceanParticles.copy()]\n",
-    "#plotTitles = [\"Initil ensemble\"]\n",
+    "oceanParticleSets = [gpuParticles.copy()]\n",
+    "plotTitles = [\"Initil ensemble\"]\n",
     "\n",
     "def animate(i):\n",
     "    if (i>0):\n",
@@ -451,13 +451,13 @@
     "    fig.suptitle(\"CDKLM16 with GPU drift and residualResampling - Time = \" + \"{:04.0f}\".format(t) + \" s\", fontsize=18)\n",
     "    \n",
     "    if (i%50 == 0 and i > 0):\n",
-    "        #oceanParticleSets.append(oceanParticles.copy())\n",
-    "        #plotTitles.append(\"Before particle filter at t = \" + str(t))\n",
+    "        oceanParticleSets.append(gpuParticles.copy())\n",
+    "        plotTitles.append(\"Before particle filter at t = \" + str(t))\n",
     "        \n",
     "        resampledOceanParticles = Resampling.residualSampling(gpuParticles, reinitialization_variance=resample_variance)\n",
     "         \n",
-    "        #oceanParticleSets.append(resampledOceanParticles.copy())\n",
-    "        #plotTitles.append(\"After particle filter at t = \" + str(t))\n",
+    "        oceanParticleSets.append(gpuParticles.copy())\n",
+    "        plotTitles.append(\"After particle filter at t = \" + str(t))\n",
     "    \n",
     "    if (i%20 == 0):\n",
     "        print \"{:03.0f}\".format(100*i / T) + \" % => t=\" + str(t) + \"\\tMax eta: \" + str(np.max(eta1)) + \\\n",
@@ -496,8 +496,8 @@
    },
    "outputs": [],
    "source": [
-    "#for i in range(len(oceanParticleSets)):\n",
-    "#    oceanParticleSets[i].plotDistanceInfo(title=plotTitles[i])"
+    "for i in range(len(oceanParticleSets)):\n",
+    "    oceanParticleSets[i].plotDistanceInfo(title=plotTitles[i])"
    ]
   },
   {

--- a/python/SWESimulators/CDKLM16.py
+++ b/python/SWESimulators/CDKLM16.py
@@ -312,7 +312,13 @@ class CDKLM16(Simulator.Simulator):
                 
                 self.bc_kernel.boundaryCondition(self.cl_queue, \
                         self.cl_data.h0, self.cl_data.hu0, self.cl_data.hv0)
-                
+              
+            if self.hasDrifters:
+                self.drifters.drift(self.cl_data.h0, self.cl_data.hu0, \
+                                    self.cl_data.hv0, np.float32(10), \
+                                    self.nx, self.ny, self.dx, self.dy, \
+                                    local_dt, \
+                                    np.int32(2), np.int32(2))
             self.t += local_dt
             
         if self.write_netcdf:

--- a/python/SWESimulators/Resampling.py
+++ b/python/SWESimulators/Resampling.py
@@ -26,7 +26,6 @@ import numpy as np
 import time
 
 import Common
-from Particles import *
 
 
 def resampleParticles(particles, newSampleIndices, reinitialization_variance):


### PR DESCRIPTION
The call to the drift kernel in CDKLM disappeared in the previous pull request. It is re-introduced in this PR, along with a small fix forgotten in CompareScheme2D notebook.