### PR TITLE
Dealing with blocksizes in a much better way

### DIFF
--- a/gpu_ocean/profiling.py
+++ b/gpu_ocean/profiling.py
@@ -123,12 +123,22 @@ if __name__ == '__main__':
     profiling_args_parser.add_argument('-ctcs', '--ctcs', dest='simulators', action='append_const', const=CTCS.CTCS)
     profiling_args_parser.add_argument('-kp', '--kp', dest='simulators', action='append_const', const=KP07.KP07)
     profiling_args_parser.add_argument('-cdklm', '--cdklm', dest='simulators', action='append_const', const=CDKLM16.CDKLM16)
-    
+    profiling_args_parser.add_argument('--block_width', type=int)
+    profiling_args_parser.add_argument('--block_height', type=int)
     
     profiling_args, remaining = profiling_args_parser.parse_known_args()
     sim_vars, remaining = sim_args_parser.parse_known_args(args=remaining)
     sim_args = vars(sim_vars)
-        
+
+    
+    if (profiling_args.block_width != None):
+        sim_args['block_width'] = profiling_args.block_width
+    if (profiling_args.block_height != None):
+        sim_args['block_height'] = profiling_args.block_height
+	
+
+    
+    
     if (remaining):
         sim_args_parser.print_help()
         profiling_args_parser.print_help()

--- a/gpu_ocean/prototypes/BenchmarkGitVersionsForProfiling.ipynb
+++ b/gpu_ocean/prototypes/BenchmarkGitVersionsForProfiling.ipynb
@@ -60,7 +60,7 @@
     "    DESKTOP = 2\n",
     "    SUPERCOMPUTER = 3\n",
     "    \n",
-    "architecture = Architecture.SUPERCOMPUTER\n"
+    "architecture = Architecture.DESKTOP\n"
    ]
   },
   {
@@ -158,31 +158,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def block_string(block_size):\n",
-    "    return \"block_width=\"+str(block_size[0])+\", block_height=\"+str(block_size[1])\n",
-    "\n",
-    "def patch_block_sizes(cdklm_py_file_path, old_block_sizes, new_block_sizes):\n",
-    "    old_string = block_string(old_block_sizes)\n",
-    "    new_string = block_string(new_block_sizes)\n",
-    "    \n",
-    "    # create temporary file\n",
-    "    tmpfile, tmpfile_abs_path = tempfile.mkstemp()\n",
-    "    with os.fdopen(tmpfile, 'w') as new_file:\n",
-    "        with open(cdklm_py_file_path) as old_file:\n",
-    "            for line in old_file:\n",
-    "                new_file.write(line.replace(old_string, new_string))\n",
-    "    # Remove original file\n",
-    "    os.remove(cdklm_py_file_path)\n",
-    "    # Move the new file\n",
-    "    shutil.move(tmpfile_abs_path, cdklm_py_file_path)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
@@ -199,27 +174,23 @@
     "    logger.debug(\"stdout: \" + str(stdout))\n",
     "        \n",
     "    if architecture == Architecture.DESKTOP or architecture == Architecture.SUPERCOMPUTER:\n",
-    "        cdklm_abs_path = os.path.join(git_clone, cdklm_python_class_relpath)\n",
+    "        block_size_options = None\n",
+    "        \n",
+    "        if architecture == Architecture.LAPTOP:\n",
+    "            block_size_options = [\"--block_width\", str(laptop_block[0]), \"--block_height\", str(laptop_block[1])] \n",
+    "\n",
+    "            \n",
     "        if architecture == Architecture.DESKTOP:\n",
-    "            patch_block_sizes(cdklm_abs_path, laptop_block, desktop_block)\n",
-    "            logger.debug(\"Changed blocksizes from \" + str(laptop_block) + \" to \" + str(desktop_block))\n",
-    "    \n",
+    "            block_size_options = [\"--block_width\", str(desktop_block[0]), \"--block_height\", str(desktop_block[1])]\n",
+    "            \n",
     "        if architecture == Architecture.SUPERCOMPUTER:\n",
-    "            patch_block_sizes(cdklm_abs_path, laptop_block, supercomputer_block)\n",
-    "            logger.debug(\"Changed blocksizes from \" + str(laptop_block) + \" to \" + str(desktop_block))\n",
-    "        \n",
-    "        # Grep on file to check that we succeeded:\n",
-    "        try:\n",
-    "            cmd = [\"grep\", \"block_width=\", cdklm_abs_path]\n",
-    "            a = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=shell, cwd=tmpdir, env=my_env)\n",
-    "        except subprocess.CalledProcessError as e:\n",
-    "            logger.error(\"Failed, return code \" + str(e.returncode) + \"\\n\" + str(e.output))\n",
-    "        logger.debug(\"Confirming block sizes through grep:\\n\" + a.decode(\"utf-8\"))\n",
-    "        \n",
+    "            block_size_options = [\"--block_width\", str(supercomputer_block[0]), \"--block_height\", str(supercomputer_block[1])]\n",
+    "                    \n",
     "    a = None\n",
     "    try:\n",
     "        #cmd = [\"python\", \"--version\"]\n",
-    "        cmd = [\"python\", os.path.join(git_clone, benchmark_script_relpath)] + benchmark_script_options + [\"--output\", \"benchmark_\" + version + \".npz\"]\n",
+    "        cmd = [\"python\", os.path.join(git_clone, benchmark_script_relpath)] + benchmark_script_options + \\\n",
+    "                [\"--output\", \"benchmark_\" + version + \".npz\"] + block_size_options\n",
     "        a = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=shell, cwd=tmpdir, env=my_env)\n",
     "    except subprocess.CalledProcessError as e:\n",
     "        logger.error(\"Failed, return code \" + str(e.returncode) + \"\\n\" + str(e.output))\n",
@@ -276,6 +247,7 @@
     "### NOTE: Static files\n",
     "outfile_laptop = os.path.join(os.getcwd(), \"laptop_cdklm_profiling.npz\")\n",
     "outfile_desktop = \"desktop_cdklm_profiling.npz\"\n",
+    "#outfile_supercomputer = outfile\n",
     "outfile_supercomputer = \"supercomputer_fermi_cdklm_profiling.npz\"\n",
     "###\n",
     "\n",
@@ -342,9 +314,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python [conda env:gpuocean]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-gpuocean-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Instead of changing the file, we use the already in-place command line arguments for block sizes available in run_benchmark.py