### PR TITLE
Model error in netcdf, and fan plot prototypes

### DIFF
--- a/gpu_ocean/SWESimulators/CDKLM16.py
+++ b/gpu_ocean/SWESimulators/CDKLM16.py
@@ -341,15 +341,11 @@ class CDKLM16(Simulator.Simulator):
             sim_reader.getBCSpongeCells())
     
         # Model errors
-        print('looking for small_scale_perturbation')
         if sim_reader.has('small_scale_perturbation'):
-            print('found ' + sim_reader.get('small_scale_perturbation') )
             sim_params['small_scale_perturbation'] = sim_reader.get('small_scale_perturbation') == 'True'
             if sim_params['small_scale_perturbation']:
                 sim_params['small_scale_perturbation_amplitude'] = sim_reader.get('small_scale_perturbation_amplitude')
                 sim_params['small_scale_perturbation_interpolation_factor'] = sim_reader.get('small_scale_perturbation_interpolation_factor')
-        else:
-            print('found nada :(')
             
             
         # Data assimilation parameters:

--- a/gpu_ocean/SWESimulators/DoubleJetCase.py
+++ b/gpu_ocean/SWESimulators/DoubleJetCase.py
@@ -190,7 +190,6 @@ class DoubleJetCase:
             "small_scale_perturbation": model_error,
             "small_scale_perturbation_amplitude": 0.0003,
             "small_scale_perturbation_interpolation_factor": 5,
-            "perturbation_frequency": 1
         }
         
         self.base_init = {
@@ -203,14 +202,12 @@ class DoubleJetCase:
            self.perturbation_type == DoubleJetPerturbationType.LowFrequencySpinUp or \
            self.perturbation_type == DoubleJetPerturbationType.LowFrequencyStandardSpinUp:
             if self.perturbation_type == DoubleJetPerturbationType.LowFrequencySpinUp:
-                self.sim_args['perturbation_frequency'] = 10
                 self.commonSpinUpTime = self.commonSpinUpTime
                 self.individualSpinUpTime = self.individualSpinUpTime*1.5
             
             
             elif self.perturbation_type == DoubleJetPerturbationType.LowFrequencyStandardSpinUp:
                 self.sim_args, self.base_init = self.getStandardPerturbedInitConditions()
-                self.sim_args['perturbation_frequency'] = 10
                 self.commonSpinUpTime = self.commonSpinUpTime*2
                 
             tmp_sim = CDKLM16.CDKLM16(**self.sim_args, **self.base_init)
@@ -223,8 +220,6 @@ class DoubleJetCase:
             self.sim_args['t'] = tmp_sim.t
             tmp_sim.cleanUp()
             
-        if self.perturbation_type == DoubleJetPerturbationType.NormalPerturbedSpinUp:
-            self.sim_args['perturbation_frequency'] = 10
             
         # The IEWPFPaperCase - isolated to give a better overview
         if self.perturbation_type == DoubleJetPerturbationType.IEWPFPaperCase:

--- a/gpu_ocean/SWESimulators/SimReader.py
+++ b/gpu_ocean/SWESimulators/SimReader.py
@@ -56,6 +56,13 @@ class SimNetCDFReader:
         except:
             return "not found"
         
+    def has(self, attr):
+        try:
+            tmp = self.ncfile.getncattr(attr)
+            return True
+        except:
+            return False
+        
     def printVariables(self):
         for var in self.ncfile.variables:
             print(var)
@@ -91,7 +98,7 @@ class SimNetCDFReader:
                   self.ghostCells[3]:-self.ghostCells[1]]
             hv = hv[self.ghostCells[2]:-self.ghostCells[0], \
                   self.ghostCells[3]:-self.ghostCells[1]]
-        return eta, hu, hv, time[index]
+        return eta, hu, hv, np.float32(time[index])
     
     def getH(self):
         H = self.ncfile.variables['H'][:, :]

--- a/gpu_ocean/SWESimulators/SimWriter.py
+++ b/gpu_ocean/SWESimulators/SimWriter.py
@@ -59,7 +59,7 @@ class SimNetCDFWriter:
         self.timestamp = datetime.datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
         self.timestamp_short = datetime.datetime.now().strftime("%Y_%m_%d")
         try:
-            self.git_hash = str.strip(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
+            self.git_hash = str.strip(str(subprocess.check_output(['git', 'rev-parse', 'HEAD'])))
         except:
             self.git_hash = "git info missing..."
 
@@ -106,7 +106,7 @@ class SimNetCDFWriter:
         self.minmod_theta = sim.theta
         self.coriolis_force = sim.f
         self.coriolis_beta = sim.coriolis_beta
-        self.y_zero_reference_cell = sim.y_zero_reference_cell
+        self.y_zero_reference_cell = sim.y_zero_reference_cell-2
         self.wind_stress = sim.wind_stress.source_filename
         self.eddy_viscosity_coefficient = sim.A
         g = sim.g
@@ -172,6 +172,28 @@ class SimNetCDFWriter:
         self.ncfile.ghost_cells_east  = self.ghost_cells_east
         self.ncfile.ghost_cells_south = self.ghost_cells_south
         self.ncfile.ghost_cells_west  = self.ghost_cells_west
+        
+        
+        # Write parameters related to stochastic model error and data assimilation
+        # At the time of writing, such parameters are only available in the CDKLM simulator.
+        if (sim.__class__.__name__ == "CDKLM16"):
+            self.model_time_step = sim.model_time_step
+            self.ncfile.model_time_step = self.model_time_step 
+            
+            self.small_scale_perturbation = sim.small_scale_perturbation
+            self.ncfile.small_scale_perturbation = str(self.small_scale_perturbation)
+            
+            if self.small_scale_perturbation:
+
+                self.small_scale_perturbation_amplitude = sim.small_scale_model_error.soar_q0
+                self.ncfile.small_scale_perturbation_amplitude = self.small_scale_perturbation_amplitude
+
+                self.small_scale_perturbation_interpolation_factor = sim.small_scale_model_error.interpolation_factor
+                self.ncfile.small_scale_perturbation_interpolation_factor = self.small_scale_perturbation_interpolation_factor
+            
+            #y_zero_reference_cell
+            
+
         
         #Create dimensions 
         self.ncfile.createDimension('time', None) #Unlimited time dimension

--- a/gpu_ocean/demos/DAPaper/FanPlotDemo.ipynb
+++ b/gpu_ocean/demos/DAPaper/FanPlotDemo.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "This software is part of GPU Ocean. \n",
+    "\n",
+    "Copyright (C) 2019  SINTEF Digital\n",
+    "\n",
+    "Creating fan plots for plotting drift trajectory forecasts.\n",
+    "\n",
+    "This program is free software: you can redistribute it and/or modify\n",
+    "it under the terms of the GNU General Public License as published by\n",
+    "the Free Software Foundation, either version 3 of the License, or\n",
+    "(at your option) any later version.\n",
+    "\n",
+    "This program is distributed in the hope that it will be useful,\n",
+    "but WITHOUT ANY WARRANTY; without even the implied warranty of\n",
+    "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n",
+    "GNU General Public License for more details.\n",
+    "\n",
+    "You should have received a copy of the GNU General Public License\n",
+    "along with this program.  If not, see <http://www.gnu.org/licenses/>.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plotting of drift trajectory forecasts\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%config InlineBackend.figure_format = 'retina'\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib\n",
+    "from matplotlib import pyplot as plt\n",
+    "from matplotlib import animation, rc\n",
+    "from scipy.special import lambertw\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "from importlib import reload\n",
+    "\n",
+    "sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), '../../')))\n",
+    "\n",
+    "#Set large figure sizes\n",
+    "rc('figure', figsize=(16.0, 12.0))\n",
+    "rc('animation', html='html5')\n",
+    "matplotlib.rcParams['contour.negative_linestyle'] = 'solid'\n",
+    "\n",
+    "#Import our simulator\n",
+    "from SWESimulators import CDKLM16, PlotHelper, Common, IPythonMagic\n",
+    "from SWESimulators import CDKLM16, Common, DoubleJetCase, GPUDrifterCollection, Observation\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cuda_context_handler gpu_ctx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a simulator\n",
+    "\n",
+    "... so that we have relevant parameters available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "doubleJetCase = DoubleJetCase.DoubleJetCase(gpu_ctx,\n",
+    "                                            DoubleJetCase.DoubleJetPerturbationType.IEWPFPaperCase)\n",
+    "\n",
+    "doubleJetCase_args, doubleJetCase_init = doubleJetCase.getInitConditions()\n",
+    "sim = CDKLM16.CDKLM16(**doubleJetCase_args, **doubleJetCase_init)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define filenames and read drifter positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.listdir('scripts/')\n",
+    "script_path = os.path.abspath('scripts')\n",
+    "truth_files = []\n",
+    "for subfolder in os.listdir('scripts/'):\n",
+    "    if subfolder.startswith('truth_2019_04_15-09'):\n",
+    "        drifter_file_name = os.path.join(os.path.join(script_path, subfolder),\n",
+    "                                         'drifter_observations.pickle')\n",
+    "        \n",
+    "        truth_files.append(drifter_file_name)\n",
+    "        \n",
+    "print(len(truth_files))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "observations = []\n",
+    "main_obs = Observation.Observation()\n",
+    "main_obs.read_pickle(truth_files[0])\n",
+    "\n",
+    "first = True\n",
+    "for pickle in truth_files:\n",
+    "    if first:\n",
+    "        first = False\n",
+    "        continue\n",
+    "    obs = Observation.Observation()\n",
+    "    obs.read_pickle(pickle)\n",
+    "    \n",
+    "    observations.append(obs)\n",
+    "print(len(observations))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_times = main_obs.get_observation_times()\n",
+    "print(obs_times)\n",
+    "print(len(obs_times))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Selecting one drifter and number of observation considered for plotting\n",
+    "drifter = 18 # 17\n",
+    "num_days = 3\n",
+    "observations_per_day = 24*12 # Every fifth minute\n",
+    "num_observations = int(num_days*observations_per_day)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "main_drifter_path = np.zeros((num_observations, 2))\n",
+    "for i in range(num_observations):\n",
+    "    obs_t = obs_times[i]\n",
+    "    main_drifter_path[i,:] = main_obs.get_drifter_position(obs_t)[drifter,:]\n",
+    "#print(main_drifter_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "paths = [None]*len(observations)\n",
+    "for i in range(len(observations)):\n",
+    "    print('processing ensemble member ' + str(i))\n",
+    "    paths[i] = np.zeros((num_observations, 2))\n",
+    "    for o in range(num_observations):\n",
+    "        obs_t = obs_times[o]\n",
+    "        paths[i][o,:] = observations[i].get_drifter_position(obs_t)[drifter,:]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a canvas for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "fig = plt.figure(figsize=(7,7))\n",
+    "ax = plt.subplot(111)\n",
+    "ax.imshow(np.zeros((sim.ny, sim.nx))*np.nan, origin=\"lower\",\n",
+    "          extent=[0, sim.nx*sim.dx, 0, sim.ny*sim.dy])\n",
+    "\n",
+    "\n",
+    "cell_id_x = int(np.floor(main_drifter_path[0,0]))\n",
+    "cell_id_y = int(np.floor(main_drifter_path[0,1]))\n",
+    "\n",
+    "\n",
+    "circ_start = matplotlib.patches.Circle((main_drifter_path[0,0], main_drifter_path[0,1]), 6000, fill=False)\n",
+    "ax.add_patch(circ_start)\n",
+    "\n",
+    "circ_end = matplotlib.patches.Circle((main_drifter_path[-1,0], main_drifter_path[-1,1]), 6000, fill=False)\n",
+    "ax.add_patch(circ_end)\n",
+    "\n",
+    "\n",
+    "\n",
+    "for path in paths:\n",
+    "    ax.plot(path[:,0], path[:,1], color='xkcd:light blue grey')\n",
+    "    \n",
+    "for path in paths:\n",
+    "    circ_end = matplotlib.patches.Circle((path[-1,0], path[-1,1]), 2000, fill=False, zorder=10)\n",
+    "    ax.add_patch(circ_end)\n",
+    "    \n",
+    "ax.plot(main_drifter_path[:,0], main_drifter_path[:,1], color='xkcd:dark grey blue')\n",
+    "\n",
+    "print('hei')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "git": {
+   "suppress_outputs": true
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:gpuocean]",
+   "language": "python",
+   "name": "conda-env-gpuocean-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/gpu_ocean/tests/oneLayer_2D_tests.py
+++ b/gpu_ocean/tests/oneLayer_2D_tests.py
@@ -34,10 +34,11 @@ from schemes.FBL_test import FBLtest
 from schemes.CTCS_test import CTCStest
 from schemes.CDKLM16_test import CDKLM16test
 from schemes.KP07_test import KP07test
+from schemes.NetCDF_test import NetCDFtest
 
 def printSupportedSchemes():
     print("Supported schemes:")
-    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07")
+    print("0: All, 1: FBL, 2: CTCS, 3: CDKLM16, 4: KP07, 5: NetCDF interface")
     
 
 if (len(sys.argv) < 2):
@@ -60,7 +61,7 @@ if (jenkins):
 # Define the tests that will be part of our test suite:
 test_classes_to_run = None
 if scheme == 0:
-    test_classes_to_run = [FBLtest, CTCStest, CDKLM16test, KP07test]
+    test_classes_to_run = [FBLtest, CTCStest, CDKLM16test, KP07test, NetCDFtest]
 elif scheme == 1:
     test_classes_to_run = [FBLtest]
 elif scheme == 2:
@@ -69,6 +70,8 @@ elif scheme == 3:
     test_classes_to_run = [CDKLM16test]
 elif scheme == 4:
     test_classes_to_run = [KP07test]
+elif scheme == 5:
+    test_classes_to_run = [NetCDFtest]
 else:
     print("Error: " + str(scheme) + " is not a supported scheme...")
     printSupportedSchemes()

--- a/gpu_ocean/tests/schemes/NetCDF_test.py
+++ b/gpu_ocean/tests/schemes/NetCDF_test.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""
+This software is part of GPU Ocean. 
+
+Copyright (C) 2019 SINTEF Digital
+
+This python module implements regression tests for writing and reading
+simulators to NetCDF.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import time
+import numpy as np
+import sys
+import os
+import gc
+
+from testUtils import *
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../')))
+
+from SWESimulators import Common, CDKLM16, SimWriter, DoubleJetCase
+
+
+class NetCDFtest(unittest.TestCase):
+
+    def setUp(self):
+        self.gpu_ctx = Common.CUDAContext()
+
+        self.sim = None
+        self.file_sim = None
+        
+        self.printall = True
+        
+    def tearDown(self):
+        if self.sim is not None:
+            self.sim.cleanUp()
+            self.sim = None
+        if self.file_sim is not None:
+            self.file_sim.cleanUp()
+            self.file_sim = None
+        
+        if self.gpu_ctx is not None:
+            self.assertEqual(sys.getrefcount(self.gpu_ctx), 2)
+            self.gpu_ctx = None
+        
+        gc.collect() # Force run garbage collection to free up memory
+        
+
+
+    def test_netcdf_cdklm(self):
+        
+        # Create simulator and write to file:
+        doubleJetCase = DoubleJetCase.DoubleJetCase(self.gpu_ctx,
+                                                    DoubleJetCase.DoubleJetPerturbationType.IEWPFPaperCase)
+
+        doubleJetCase_args, doubleJetCase_init = doubleJetCase.getInitConditions()
+        netcdf_args = {
+            'write_netcdf': True,
+            'netcdf_filename': 'netcdf_test/netcdf_test.nc'
+        }
+        self.sim = CDKLM16.CDKLM16(**doubleJetCase_args, **doubleJetCase_init, **netcdf_args)
+        self.sim.closeNetCDF()
+        
+        
+        # Create new simulator from the newly created file
+        self.file_sim = CDKLM16.CDKLM16.fromfilename(self.gpu_ctx, netcdf_args['netcdf_filename'], cont_write_netcdf=False)
+        
+        # Loop over object attributes and compare those that are scalars
+        for attr in dir(self.sim):
+            if not attr.startswith('__'):
+                if np.isscalar(getattr(self.sim, attr)):
+                    sim_attr      = getattr(self.sim,      attr)
+                    file_sim_attr = getattr(self.file_sim, attr)
+
+                    # Round the simulation time to make it comparable
+                    if attr == 't':
+                        file_sim_attr = round(file_sim_attr) 
+                        sim_attr      = round(sim_attr)
+
+                    # Create error message and compare values of attributes
+                    assert_msg = "Discrepancy in attribute " + attr + ":\n" + \
+                                 "         sim."+ attr + ": " + str(sim_attr) + \
+                                 "    file_sim."+ attr + ": " + str(file_sim_attr)
+                    self.assertEqual(sim_attr, file_sim_attr, msg=assert_msg)
+                    
+                    if self.printall:
+                        print('file_sim.' + attr + ': ' + str(file_sim_attr))
+                        print('     sim.' + attr + ': ' + str(sim_attr))
+                        if np.isreal(file_sim_attr):
+                            print('Diff: ' + str(file_sim_attr - sim_attr))
+                        print('')
+
+                    #if np.isreal(getattr(file_sim, attr)):
+                    #    print('Diff: ' + str(getattr(file_sim, attr) - getattr(sim, attr)))
+
+        # Loop over attributes in the model error
+        for attr in dir(self.sim.small_scale_model_error):
+            if not attr.startswith('__'):
+                if np.isscalar(getattr(self.sim.small_scale_model_error, attr)):
+                    
+                    sim_attr      = getattr(self.sim.small_scale_model_error,      attr)
+                    file_sim_attr = getattr(self.file_sim.small_scale_model_error, attr)
+                    
+                    # Create error message and compare values of attributes
+                    assert_msg = "Discrepancy in attribute " + attr + ":\n" + \
+                                 "         sim.small_scale_model_error"+ attr + ": " + str(sim_attr) + \
+                                 "    file_sim.small_scale_model_error"+ attr + ": " + str(file_sim_attr)
+                    self.assertEqual(sim_attr, file_sim_attr, msg=assert_msg)
+                    
+                    if self.printall:
+                        print('file_sim.small_scale_model_error.' + attr + ': ' + str(file_sim_attr))
+                        print('     sim.small_scale_model_error.' + attr + ': ' + str(sim_attr))
+                        if np.isreal(file_sim_attr):
+                            print('Diff: ' + str(file_sim_attr - sim_attr))
+                        print('')
+
+                        
+        # Compare ocean state:
+        s_eta0, s_hu0, s_hv0 = self.sim.download()
+        f_eta0, f_hu0, f_hv0 = self.file_sim.download()
+        self.checkResults(s_eta0, s_hu0, s_hv0, f_eta0, f_hu0, f_hv0)
+        
+        dt = self.sim.dt
+        self.sim.step(100*dt, apply_stochastic_term=False)
+        self.file_sim.step(100*dt, apply_stochastic_term=False)
+        s_eta0, s_hu0, s_hv0 = self.sim.download()
+        f_eta0, f_hu0, f_hv0 = self.file_sim.download()
+        self.checkResults(s_eta0, s_hu0, s_hv0, f_eta0, f_hu0, f_hv0)
+        
+        
+         
+    def checkResults(self, sim_eta, sim_hu, sim_hv, file_eta, file_hu, file_hv):
+        diffEta = np.linalg.norm(sim_eta - file_hu) / np.max(np.abs(file_eta))
+        diffU = np.linalg.norm(sim_hu - file_hu) / np.max(np.abs(file_hu))
+        diffV = np.linalg.norm(sim_hv - file_hv) / np.max(np.abs(file_hv))
+        maxDiffEta = np.max(sim_eta - file_eta) / np.max(np.abs(file_eta))
+        maxDiffU = np.max(sim_hu - file_hu) / np.max(np.abs(file_hu))
+        maxDiffV = np.max(sim_hv - file_hv) / np.max(np.abs(file_hv))
+        
+        self.assertAlmostEqual(maxDiffEta, 0.0, places=3,
+                               msg='Unexpected eta difference! Max rel diff: ' + str(maxDiffEta) + ', L2 rel diff: ' + str(diffEta))
+        self.assertAlmostEqual(maxDiffU, 0.0, places=3,
+                               msg='Unexpected hu relative difference: ' + str(maxDiffU) + ', L2 rel diff: ' + str(diffU))
+        self.assertAlmostEqual(maxDiffV, 0.0, places=3,
+                               msg='Unexpected hv relative difference: ' + str(maxDiffV) + ', L2 rel diff: ' + str(diffV))
+    
+        # Test maximal time step:
+        self.sim.updateDt()
+        dt_host = self.sim._getMaxTimestepHost()
+        self.assertEqual(self.sim.dt, dt_host, msg="maximum time step")
+        
+        if self.printall:
+            print("Test of state successful")
+        
+        
+ 


### PR DESCRIPTION
The SimWriter now extracts information about the stochastic model errors, so that a simulator created from the NetCDF file will still sample model errors from with the same parameters.

New test (takes  ~17 seconds on my desktop) is implemented in order to warn us about new attributes in the CDKLM simulator which is not written to NetCDF, or not read from NetCDF when initializing a CDKLM simulator from file:
```
cd gpu_ocean/tests
python oneLayer_2D_tests.py 5
```

To see details from the test, modify the boolean variable `self.printall` in  `gpu_ocean/tests/schemes/NetCDF_test.py`.
