### PR TITLE
bugfix related to wall BC only visible with mixed BC

### DIFF
--- a/gpu_ocean/SWESimulators/gpu_kernels/CDKLM16_kernel.cu
+++ b/gpu_ocean/SWESimulators/gpu_kernels/CDKLM16_kernel.cu
@@ -690,14 +690,14 @@ __global__ void cdklm_swe_2D(
                     tx+1, ty, bx, 
                     R, Qx, Hi,
                     coriolis_f_central, coriolis_f_right, 
-                    bc_north, bc_south, 
+                    bc_east, bc_west, 
                     north)
                 - 
                 computeFFaceFlux(
                     tx , ty, bx,  
                     R, Qx, Hi,
                     coriolis_f_left, coriolis_f_central, 
-                    bc_north, bc_south, 
+                    bc_east, bc_west, 
                     north)) / DX;
     }
     __syncthreads();
@@ -787,14 +787,14 @@ __global__ void cdklm_swe_2D(
                 tx, ty+1, by, 
                 R, Qx, Hi, 
                 coriolis_f_central, coriolis_f_upper, 
-                bc_east, bc_west, 
+                bc_north, bc_south, 
                 east)
             - 
             computeGFaceFlux(
                 tx, ty, by,  
                 R, Qx, Hi, 
                 coriolis_f_lower, coriolis_f_central, 
-                bc_east, bc_west, 
+                bc_north, bc_south, 
                 east)) / DY;
         __syncthreads();
     }


### PR DESCRIPTION
Fixed bug that ruined conservation of mass when the boundary conditions were a mix of wall and other. 

See https://github.com/metno/gpuocean/pull/4 